### PR TITLE
Copy README to docs/ and remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # nkn-client-js
 
-[English](/docs/README-en.md) •
+[English](/README.md) •
 [Русский](/docs/README-ru.md)
 
 JavaScript implementation of NKN client.

--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -1,1 +1,0 @@
-../README.md

--- a/docs/README-ru.md
+++ b/docs/README-ru.md
@@ -2,7 +2,7 @@
 
 # nkn-client-js
 
-[English](/docs/README-en.md) •
+[English](/README.md) •
 [Русский](/docs/README-ru.md)
 
 JavaScript реализация NKN клиента.


### PR DESCRIPTION
Fix the dead link when clicking on the `English` button in README.md and README-ru.md

Now the /README.md points to either docs/README-en or docs/README-ru to avoid duplicate data in /README.md and docs/README-en.md


Signed-off-by: John Smith <jsmith@jsmith.cz>